### PR TITLE
Removed config artifacts from RC module to clean up .ironrc.

### DIFF
--- a/lib/questions.js
+++ b/lib/questions.js
@@ -5,7 +5,7 @@ var runQuestions = function(){
     var config    = rc.init();
     var questions = [];
 
-    if( config ){
+    if( config.exists ){
 
         // questions for altering or adding to existing projects
         questions = require('./questions/project');

--- a/lib/solutions.js
+++ b/lib/solutions.js
@@ -4,7 +4,7 @@ module.exports = function( data ){
 
     var config      = rc.init();
 
-    if( config ){
+    if( config.exists ){
 
         // answers for altering or adding to existing projects
         require('./solutions/project')( data );

--- a/lib/solutions/clientlibs.js
+++ b/lib/solutions/clientlibs.js
@@ -29,7 +29,7 @@
 
 
 module.exports = function( answers ){
-    var ironRc    = require( 'rc' )( 'iron' );
+    var ironRc    = rcManager.init().config;
     var cwd       = shell.pwd();
     var styleType = ironRc.css_preprocessor !== false ? ironRc.css_preprocessor : 'css';
 

--- a/lib/solutions/components.js
+++ b/lib/solutions/components.js
@@ -10,7 +10,7 @@ var exit             = require( '../exit');
 
 module.exports = function( answers_main ){
 
-    var ironRc = require( 'rc' )('iron');
+    var ironRc = rcManager.init().config;
 
     var newQuestions = answers_main.components_clientlibrary.map( function( lib ) {
 

--- a/lib/utils/manageRC.js
+++ b/lib/utils/manageRC.js
@@ -10,15 +10,21 @@ module.exports = {
             templates           : {}
         });
 
-        var hadConfig = false;
+        var rcResult = {};
+        rcResult.exists = config.configs ? true : false;
 
-        if( config.configs ){
-            hadConfig = true;
+        if( rcResult.exists ){
+            var configProps = ["config", "configs"];
+            rcResult.config = config;
+
+            configProps.filter(function(prop) {
+                if (rcResult.config.hasOwnProperty(prop))
+                    delete rcResult.config[prop];
+            });
         }
 
-        return hadConfig ? config : hadConfig;
-
-    } ,
+        return rcResult;
+    },
 
     update : function( updatedRc ){
 


### PR DESCRIPTION
 rcManager now returns object containing cleaned rc file and rc file existence flag, which prevents the `config` string and `config[]` array from being added to the config file. This should prevent merge conflicts within the config file.
